### PR TITLE
Take API credentials from env.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,30 +6,29 @@ Golang client for Mixpanel API
 
 ## Getting Started
 
-``` 
+```
 package main
 
 import (
-  "fmt"
-  "github.com/austinchau/go-mixpanel"
+	"fmt"
+
+	mixpanel "github.com/austinchau/go-mixpanel"
 )
 
 func main() {
-  key = "YOUR_API_KEY"
-  secret = "YOUR_API_SECRET"
-  mp := mixpanel.NewMixpanel(key, secret)
-  
-  params := map[string]string{
-    "from_date": "2015-01-01",
-    "to_date": "2015-01-01",
-    "event": "EventA,EventB" // omit "event" to retrieve all events
-  }
+	mp := mixpanel.NewMixpanel()
 
-  result, err := mp.ExportQuery(params)
-  if err != nil {
-    panic(err)
-  }  
-  fmt.Printf("%+v", result)
+	params := map[string]string{
+		"from_date": "2015-01-01",
+		"to_date":   "2015-01-01",
+		"event":     "EventA,EventB", // omit "event" to retrieve all events
+	}
+
+	result, err := mp.ExportQuery(params)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v", result)
 }
 ```
 
@@ -41,5 +40,13 @@ go install github.com/austinchau/go-mixpanel/mixpanelexport
 ```
 
 ```
-mixpanelexport -start=2015-01-01 -end=2015-01-01 -key="YOUR_API_KEY" -secret="YOUR_API_SECRET" -event="EventA,EventB"
+mixpanelexport -start=2015-01-01 -end=2015-01-01 -event="EventA,EventB"
+```
+
+
+Expects mixpanel api credentials to be exported as environment variables.
+
+```
+export MIXPANEL_API_KEY="YOUR_KEY"
+export MIXPANEL_SECRET="YOUR_SECRET"
 ```

--- a/mixpanelexport/main.go
+++ b/mixpanelexport/main.go
@@ -1,58 +1,57 @@
 package main
 
 import (
-  "fmt"
-  "github.com/austinchau/go-mixpanel"
-  "flag"  
-  "os"
-  "io/ioutil"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	mixpanel "github.com/austinchau/go-mixpanel"
 )
 
 var (
-  m *mixpanel.Mixpanel
-  key string
-  secret string
-  event string
-  start string
-  end string
-  output string
+	m      *mixpanel.Mixpanel
+	key    string
+	secret string
+	event  string
+	start  string
+	end    string
+	output string
 )
 
 func init() {
-	flag.StringVar(&key, "key", "", "Mixpanel API Key")
-	flag.StringVar(&secret, "secret",  "", "Mixpanel API Secret")
 	flag.StringVar(&event, "event", "", "Event Name")
-	flag.StringVar(&start, "start",  "2015-01-01", "Start Date")
+	flag.StringVar(&start, "start", "2015-01-01", "Start Date")
 	flag.StringVar(&end, "end", "2015-01-01", "End Date")
 	flag.StringVar(&output, "output", "", "Output File")
-  flag.Parse()
+	flag.Parse()
 }
 
 func main() {
-  if key == "" || secret == "" || start == "" || end == "" {
-    flag.Usage()
-    os.Exit(1)
-  }
-  
-  m = mixpanel.NewMixpanel(key, secret)  
-  params := map[string]string{
-    "from_date": start,
-    "to_date": end,
-    "event": event,
-  }
-  
-  m.BaseUrl = "http://data.mixpanel.com/api/2.0"
-  bytes, err := m.MakeRequest("export", params)
-  if err != nil {
-    panic(err)
-  }
-  if output == "" {
-    fmt.Println(string(bytes))
-  } else {
-    err := ioutil.WriteFile(output, bytes, 0644)
-    if err != nil {
-      fmt.Println(err.Error())
-      os.Exit(1)
-    }
-  }
+	if start == "" || end == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	m = mixpanel.NewMixpanel(key, secret)
+	params := map[string]string{
+		"from_date": start,
+		"to_date":   end,
+		"event":     event,
+	}
+
+	m.BaseUrl = "http://data.mixpanel.com/api/2.0"
+	bytes, err := m.MakeRequest("export", params)
+	if err != nil {
+		panic(err)
+	}
+	if output == "" {
+		fmt.Println(string(bytes))
+	} else {
+		err := ioutil.WriteFile(output, bytes, 0644)
+		if err != nil {
+			fmt.Println(err.Error())
+			os.Exit(1)
+		}
+	}
 }


### PR DESCRIPTION
Hey, I used the mixpanelexport tool, and it works great. Its very fast too. But the `API_KEY` and `SECRET` is taken as a command line parameter which is generally discouraged (shows up in bash_history etc). I have implemented a patch which would take those settings from environment variables. Also formatted `mixpanelexport/main.go` and the example snippet in README using `gofmt`.

@austinchau Your thoughts ?
